### PR TITLE
小ボタンの文字統一のミスを修正

### DIFF
--- a/mori-no-kuni.html
+++ b/mori-no-kuni.html
@@ -282,7 +282,7 @@
         </div>
         <div class="bar_button_sm">
           <a href="#">
-            <p>詳しくはこちら</p>
+            <p>もっと見る</p>
             <span class="material-symbols-outlined">arrow_forward_ios</span>
           </a>
         </div>


### PR DESCRIPTION
instagramのアカウントページに飛ぶボタンなのに「詳しくはこちら」になっている箇所があったので、「もっと見る」に修正しました